### PR TITLE
feat(special treatment of port number 443)

### DIFF
--- a/src/RPCClient.js
+++ b/src/RPCClient.js
@@ -15,7 +15,7 @@ const defaultHost = '127.0.0.1';
  */
 async function request(url, method, params, options = {}) {
   const destination = url.host
-    ? `http://${url.host ? url.host : defaultHost}:${url.port ? url.port : ''}` : url;
+    ? `${url.port === 443 ? 'https' : 'http'}://${url.host ? url.host : defaultHost}:${url.port && url.port !== 443 ? url.port : ''}` : url;
   const payload = {
     jsonrpc: '2.0',
     method,


### PR DESCRIPTION
When port 443 is specified for port number, connect to `https://{url.host}` instead of `http://{url.host}:443`.  
This allows modern browsers to use the API on pages served over HTTPS.

Relates to #81