### PR TITLE
feat: retry request on UNIMPLEMENTED error

### DIFF
--- a/lib/transport/GrpcTransport.js
+++ b/lib/transport/GrpcTransport.js
@@ -75,6 +75,7 @@ class GrpcTransport {
         && error.code !== GrpcErrorCodes.UNAVAILABLE
         && error.code !== GrpcErrorCodes.INTERNAL
         && error.code !== GrpcErrorCodes.CANCELLED
+        && error.code !== GrpcErrorCodes.UNIMPLEMENTED
         && error.code !== GrpcErrorCodes.UNKNOWN) {
         throw error;
       }

--- a/test/unit/transport/GrpcTransport.spec.js
+++ b/test/unit/transport/GrpcTransport.spec.js
@@ -309,6 +309,25 @@ describe('GrpcTransport', () => {
         expect(requestFunc).to.be.calledTwice();
       });
 
+      it('should retry the request if a unimplemented error has thrown', async () => {
+        const error = new Error('Internal error');
+        error.code = GrpcErrorCodes.UNIMPLEMENTED;
+
+        requestFunc.onCall(0).throws(error);
+
+        const receivedData = await grpcTransport.request(
+          clientClassMock,
+          method,
+          requestMessage,
+          options,
+        );
+
+        expect(receivedData).to.deep.equal(data);
+        expect(createDAPIAddressProviderFromOptionsMock).to.be.calledTwice();
+        expect(clientClassMock).to.be.calledTwice();
+        expect(requestFunc).to.be.calledTwice();
+      });
+
       it('should retry the request if a GRPC unknown error has thrown', async () => {
         const error = new Error('Internal error');
         error.code = GrpcErrorCodes.UNKNOWN;


### PR DESCRIPTION
## Issue being fixed or feature implemented

When a client make a request that doesn’t support a specific gRPC service version (DAPI has outdated version) it won’t be able to do that due unknown gRPC service name requested by the client, therefore we want to try another one.


## What was done?
- feat: Request retry on UNIMPLEMENTED

## How Has This Been Tested?
- added unit test. 
- adding additional test in test-suite

## Breaking Changes
N/A

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added or updated relevant unit/integration/functional/e2e tests
- [X] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [X] I have assigned this pull request to a milestone
