### PR TITLE
fix: extended buffers can't be converted to UInt8Array

### DIFF
--- a/lib/methods/platform/getDataContractFactory.js
+++ b/lib/methods/platform/getDataContractFactory.js
@@ -16,14 +16,18 @@ function getDataContractFactory(grpcTransport) {
    * Fetch Data Contract by id
    *
    * @typedef {getDataContract}
-   * @param {string} contractId
+   * @param {Buffer|Identifier} contractId
    * @param {DAPIClientOptions} [options]
    * @returns {Promise<Buffer>}
    */
   async function getDataContract(contractId, options = {}) {
     const getDataContractRequest = new GetDataContractRequest();
 
-    getDataContractRequest.setId(contractId);
+    // need to convert Identifier to pure buffer as google protobuf doesn't support extended buffers
+    // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
+    const contractIdBuffer = Buffer.from(contractId);
+
+    getDataContractRequest.setId(contractIdBuffer);
 
     let getDataContractResponse;
     try {

--- a/lib/methods/platform/getDataContractFactory.js
+++ b/lib/methods/platform/getDataContractFactory.js
@@ -16,18 +16,22 @@ function getDataContractFactory(grpcTransport) {
    * Fetch Data Contract by id
    *
    * @typedef {getDataContract}
-   * @param {Buffer|Identifier} contractId
+   * @param {Buffer} contractId
    * @param {DAPIClientOptions} [options]
    * @returns {Promise<Buffer>}
    */
   async function getDataContract(contractId, options = {}) {
     const getDataContractRequest = new GetDataContractRequest();
 
-    // need to convert Identifier to pure buffer as google protobuf doesn't support extended buffers
+    // need to convert objects inherited from Buffer to pure buffer as google protobuf
+    // doesn't support extended buffers
     // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
-    const contractIdBuffer = Buffer.from(contractId);
+    if (Buffer.isBuffer(contractId)) {
+      // eslint-disable-next-line no-param-reassign
+      contractId = Buffer.from(contractId);
+    }
 
-    getDataContractRequest.setId(contractIdBuffer);
+    getDataContractRequest.setId(contractId);
 
     let getDataContractResponse;
     try {

--- a/lib/methods/platform/getDocumentsFactory.js
+++ b/lib/methods/platform/getDocumentsFactory.js
@@ -16,7 +16,7 @@ function getDocumentsFactory(grpcTransport) {
    * Fetch Documents from Drive
    *
    * @typedef {getDocuments}
-   * @param {string} contractId - Data Contract ID
+   * @param {Buffer|Identifier} contractId - Data Contract ID
    * @param {string} type - Document type
    * @param {DAPIClientOptions & getDocumentsOptions} [options]
    * @returns {Promise<Buffer[]>}
@@ -41,7 +41,12 @@ function getDocumentsFactory(grpcTransport) {
     }
 
     const getDocumentsRequest = new GetDocumentsRequest();
-    getDocumentsRequest.setDataContractId(contractId);
+    // need to convert Identifier to pure buffer as google protobuf doesn't support extended buffers
+    // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
+
+    const contractIdBuffer = Buffer.from(contractId);
+
+    getDocumentsRequest.setDataContractId(contractIdBuffer);
     getDocumentsRequest.setDocumentType(type);
     getDocumentsRequest.setWhere(whereSerialized);
     getDocumentsRequest.setOrderBy(orderBySerialized);

--- a/lib/methods/platform/getDocumentsFactory.js
+++ b/lib/methods/platform/getDocumentsFactory.js
@@ -16,7 +16,7 @@ function getDocumentsFactory(grpcTransport) {
    * Fetch Documents from Drive
    *
    * @typedef {getDocuments}
-   * @param {Buffer|Identifier} contractId - Data Contract ID
+   * @param {Buffer} contractId - Data Contract ID
    * @param {string} type - Document type
    * @param {DAPIClientOptions & getDocumentsOptions} [options]
    * @returns {Promise<Buffer[]>}
@@ -44,9 +44,15 @@ function getDocumentsFactory(grpcTransport) {
     // need to convert Identifier to pure buffer as google protobuf doesn't support extended buffers
     // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
 
-    const contractIdBuffer = Buffer.from(contractId);
+    // need to convert objects inherited from Buffer to pure buffer as google protobuf
+    // doesn't support extended buffers
+    // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
+    if (Buffer.isBuffer(contractId)) {
+      // eslint-disable-next-line no-param-reassign
+      contractId = Buffer.from(contractId);
+    }
 
-    getDocumentsRequest.setDataContractId(contractIdBuffer);
+    getDocumentsRequest.setDataContractId(contractId);
     getDocumentsRequest.setDocumentType(type);
     getDocumentsRequest.setWhere(whereSerialized);
     getDocumentsRequest.setOrderBy(orderBySerialized);

--- a/lib/methods/platform/getIdentityFactory.js
+++ b/lib/methods/platform/getIdentityFactory.js
@@ -16,17 +16,21 @@ function getIdentityFactory(grpcTransport) {
    * Fetch the identity by id
    *
    * @typedef {getIdentity}
-   * @param {Buffer|Identifier} id
+   * @param {Buffer} id
    * @param {DAPIClientOptions} [options]
    * @returns {Promise<!Buffer|null>}
    */
   async function getIdentity(id, options = {}) {
     const getIdentityRequest = new GetIdentityRequest();
-    // need to convert Identifier to pure buffer as google protobuf doesn't support extended buffers
+    // need to convert objects inherited from Buffer to pure buffer as google protobuf
+    // doesn't support extended buffers
     // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
-    const idBuffer = Buffer.from(id);
+    if (Buffer.isBuffer(id)) {
+      // eslint-disable-next-line no-param-reassign
+      id = Buffer.from(id);
+    }
 
-    getIdentityRequest.setId(idBuffer);
+    getIdentityRequest.setId(id);
 
     let getIdentityResponse;
     try {

--- a/lib/methods/platform/getIdentityFactory.js
+++ b/lib/methods/platform/getIdentityFactory.js
@@ -16,13 +16,17 @@ function getIdentityFactory(grpcTransport) {
    * Fetch the identity by id
    *
    * @typedef {getIdentity}
-   * @param {string} id
+   * @param {Buffer|Identifier} id
    * @param {DAPIClientOptions} [options]
    * @returns {Promise<!Buffer|null>}
    */
   async function getIdentity(id, options = {}) {
     const getIdentityRequest = new GetIdentityRequest();
-    getIdentityRequest.setId(id);
+    // need to convert Identifier to pure buffer as google protobuf doesn't support extended buffers
+    // https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049
+    const idBuffer = Buffer.from(id);
+
+    getIdentityRequest.setId(idBuffer);
 
     let getIdentityResponse;
     try {

--- a/package-lock.json
+++ b/package-lock.json
@@ -297,9 +297,9 @@
       }
     },
     "@dashevo/dpp": {
-      "version": "0.16.0-dev.6",
-      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.16.0-dev.6.tgz",
-      "integrity": "sha512-vT0GA+g1LYuWRHo9+Rnj8whj6Q0EYhZlzNpIoKUSDJhmji4sp3BblnioQkx/FVeDaVPccLuHo56RkZdIrxzj8Q==",
+      "version": "0.16.0-dev.7",
+      "resolved": "https://registry.npmjs.org/@dashevo/dpp/-/dpp-0.16.0-dev.7.tgz",
+      "integrity": "sha512-ePhEH9DCqMJy6J2KS7l9Jbxf0QxA9uIoRx3/AL8KZfpHKu1AjLlV36M5snnCLKbUsh3sOmoFqBWpn8S0OCGffQ==",
       "dev": true,
       "requires": {
         "@apidevtools/json-schema-ref-parser": "^8.0.0",
@@ -338,6 +338,28 @@
       "requires": {
         "lodash.camelcase": "^4.3.0",
         "protobufjs": "^6.8.6"
+      },
+      "dependencies": {
+        "protobufjs": {
+          "version": "6.10.1",
+          "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.10.1.tgz",
+          "integrity": "sha512-pb8kTchL+1Ceg4lFd5XUpK8PdWacbvV5SK2ULH2ebrYtl4GjJmS24m6CKME67jzV53tbJxHlnNOSqQHbTsR9JQ==",
+          "requires": {
+            "@protobufjs/aspromise": "^1.1.2",
+            "@protobufjs/base64": "^1.1.2",
+            "@protobufjs/codegen": "^2.0.4",
+            "@protobufjs/eventemitter": "^1.1.0",
+            "@protobufjs/fetch": "^1.1.0",
+            "@protobufjs/float": "^1.0.2",
+            "@protobufjs/inquire": "^1.1.0",
+            "@protobufjs/path": "^1.1.2",
+            "@protobufjs/pool": "^1.1.0",
+            "@protobufjs/utf8": "^1.1.0",
+            "@types/long": "^4.0.1",
+            "@types/node": "^13.7.0",
+            "long": "^4.0.0"
+          }
+        }
       }
     },
     "@istanbuljs/load-nyc-config": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.10.2",
-    "@dashevo/dpp": "~0.16.0-dev.5",
+    "@dashevo/dpp": "~0.16.0-dev.7",
     "babel-loader": "^8.0.6",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",

--- a/test/unit/methods/platform/getDataContractFactory.spec.js
+++ b/test/unit/methods/platform/getDataContractFactory.spec.js
@@ -80,7 +80,7 @@ describe('getDataContractFactory', () => {
     grpcTransportMock.request.throws(error);
 
     const request = new GetDataContractRequest();
-    request.setId(contractId);
+    request.setId(contractId.toBuffer());
 
     try {
       await getDataContract(contractId, options);

--- a/test/unit/methods/platform/getDataContractFactory.spec.js
+++ b/test/unit/methods/platform/getDataContractFactory.spec.js
@@ -42,12 +42,12 @@ describe('getDataContractFactory', () => {
     const request = new GetDataContractRequest();
     request.setId(contractId);
 
-    expect(grpcTransportMock.request).to.be.calledOnceWithExactly(
+    expect(grpcTransportMock.request.getCall(0).args).to.have.deep.members([
       PlatformPromiseClient,
       'getDataContract',
       request,
       options,
-    );
+    ]);
     expect(result).to.deep.equal(dataContractFixture.toBuffer());
   });
 
@@ -64,12 +64,12 @@ describe('getDataContractFactory', () => {
     const request = new GetDataContractRequest();
     request.setId(contractId);
 
-    expect(grpcTransportMock.request).to.be.calledOnceWithExactly(
+    expect(grpcTransportMock.request.getCall(0).args).to.have.deep.members([
       PlatformPromiseClient,
       'getDataContract',
       request,
       options,
-    );
+    ]);
     expect(result).to.equal(null);
   });
 

--- a/test/unit/methods/platform/getIdentityFactory.spec.js
+++ b/test/unit/methods/platform/getIdentityFactory.spec.js
@@ -41,7 +41,7 @@ describe('getIdentityFactory', () => {
     const result = await getIdentity(identityId, options);
 
     const request = new GetIdentityRequest();
-    request.setId(identityId);
+    request.setId(identityId.toBuffer());
 
     expect(grpcTransportMock.request).to.be.calledOnceWithExactly(
       PlatformPromiseClient,
@@ -61,7 +61,7 @@ describe('getIdentityFactory', () => {
     const result = await getIdentity(identityId, options);
 
     const request = new GetIdentityRequest();
-    request.setId(identityId);
+    request.setId(identityId.toBuffer());
 
     expect(grpcTransportMock.request).to.be.calledOnceWithExactly(
       PlatformPromiseClient,
@@ -78,7 +78,7 @@ describe('getIdentityFactory', () => {
     grpcTransportMock.request.throws(error);
 
     const request = new GetIdentityRequest();
-    request.setId(identityId);
+    request.setId(identityId.toBuffer());
 
     try {
       await getIdentity(identityId, options);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
convert objects inherited from Buffer to pure buffer as google protobuf doesn't support extended buffers https://github.com/protocolbuffers/protobuf/blob/master/js/binary/utils.js#L1049

## What was done?
<!--- Describe your changes in detail -->
Check if an object is exteneded from a buffer and clone its contents to a base buffer

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
run tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
none

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
