### PR TITLE
fix: return `Buffer` instead of `Uint8Array`

### DIFF
--- a/lib/methods/platform/getIdentitiesByPublicKeyHashesFactory.js
+++ b/lib/methods/platform/getIdentitiesByPublicKeyHashesFactory.js
@@ -43,7 +43,7 @@ function getIdentitiesByPublicKeyHashesFactory(grpcTransport) {
     }
 
     return getIdentitiesByPublicKeyHashesResponse.getIdentitiesList()
-      .map((identity) => (identity.length > 0 ? identity : null));
+      .map((identity) => (identity.length > 0 ? Buffer.from(identity) : null));
   }
 
   return getIdentitiesByPublicKeyHashes;

--- a/lib/methods/platform/getIdentityIdsByPublicKeyHashesFactory.js
+++ b/lib/methods/platform/getIdentityIdsByPublicKeyHashesFactory.js
@@ -43,7 +43,7 @@ function getIdentityIdsByPublicKeyHashesFactory(grpcTransport) {
     }
 
     return getIdentityIdsByPublicKeyHashesResponse.getIdentityIdsList()
-      .map((identityId) => (identityId.length > 0 ? identityId : null));
+      .map((identityId) => (identityId.length > 0 ? Buffer.from(identityId) : null));
   }
 
   return getIdentityIdsByPublicKeyHashes;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Invalid types were returned by new methods

## What was done?
<!--- Describe your changes in detail -->
Wrap result using `Buffer#from`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests.

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
