### PR TITLE
fix: broadcastStateTransition is timing out on testnet

### DIFF
--- a/lib/methods/platform/broadcastStateTransitionFactory.js
+++ b/lib/methods/platform/broadcastStateTransitionFactory.js
@@ -19,6 +19,14 @@ function broadcastStateTransitionFactory(grpcTransport) {
    * @returns {Promise<!BroadcastStateTransitionResponse>}
    */
   async function broadcastStateTransition(stateTransition, options = {}) {
+    // eslint-disable-next-line no-param-reassign
+    options = {
+      // Override global timeout option
+      // and timeout for this method by default
+      timeout: undefined,
+      ...options,
+    };
+
     const broadcastStateTransitionRequest = new BroadcastStateTransitionRequest();
     broadcastStateTransitionRequest.setStateTransition(stateTransition);
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
`broadcastStateTransition` is timing out on testnet and larger networks

## What was done?
<!--- Describe your changes in detail -->
Overwrite default timeout for `broadcastStateTransition`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Broadcasting transactions

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
