### PR TITLE
feat: replace all MN addresses with localhost is the network is local

### DIFF
--- a/lib/dapiAddressProvider/ListDAPIAddressProvider.js
+++ b/lib/dapiAddressProvider/ListDAPIAddressProvider.js
@@ -28,7 +28,8 @@ class ListDAPIAddressProvider {
     // This is a temporary fix for a localhost masternode.
     // On mac os, internal docker IP is used to register masternode, and it's
     // not really possible to bind to that address, so that workaround is introduced.
-    if (networks.get(this.options.network).regtestEnabled) {
+    const network = networks.get(this.options.network);
+    if (network && network.regtestEnabled) {
       liveAddress.host = '127.0.0.1';
     }
 

--- a/lib/dapiAddressProvider/ListDAPIAddressProvider.js
+++ b/lib/dapiAddressProvider/ListDAPIAddressProvider.js
@@ -28,7 +28,7 @@ class ListDAPIAddressProvider {
     // This is a temporary fix for a localhost masternode.
     // On mac os, internal docker IP is used to register masternode, and it's
     // not really possible to bind to that address, so that workaround is introduced.
-    if (networks.get(this.options.network).isRegtestEnabled) {
+    if (networks.get(this.options.network).regtestEnabled) {
       liveAddress.host = '127.0.0.1';
     }
 

--- a/lib/dapiAddressProvider/ListDAPIAddressProvider.js
+++ b/lib/dapiAddressProvider/ListDAPIAddressProvider.js
@@ -1,4 +1,5 @@
 const sample = require('lodash.sample');
+const networks = require('@dashevo/dashcore-lib/lib/networks');
 
 class ListDAPIAddressProvider {
   /**
@@ -22,7 +23,16 @@ class ListDAPIAddressProvider {
   async getLiveAddress() {
     const liveAddresses = this.getLiveAddresses();
 
-    return sample(liveAddresses);
+    const liveAddress = sample(liveAddresses);
+
+    // This is a temporary fix for a localhost masternode.
+    // On mac os, internal docker IP is used to register masternode, and it's
+    // not really possible to bind to that address, so that workaround is introduced.
+    if (networks.get(this.options.network).isRegtestEnabled) {
+      liveAddress.host = '127.0.0.1';
+    }
+
+    return liveAddress;
   }
 
   /**


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Platform test suite not working on mac os due to local network docker setup binding to a different IP

## What was done?
<!--- Describe your changes in detail -->
Add check if the network is regtest replace dapi addresses with localhost, so all network calls will be rerouted through localhost for tests on mac os

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Run platform test suite with that dapi-client

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None?

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
