### PR TITLE
fix: metadata height type was uint32 instead of int64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -249,9 +249,9 @@
       "integrity": "sha512-sJpx3F5xcVV/9jNYJQtvimo4Vfld/nD3ph+ZWtQzZ03Zo8rJC7QKQTRcIGS13Rcz80DwFNthCWMrd58vpY4ZAQ=="
     },
     "@dashevo/dapi-grpc": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.20.0.tgz",
-      "integrity": "sha512-CSmMC/Y+1U6YD/pSK3oIUG7AGFvdL9omdGzJMtyrBvsx6+JVslx3yfyB74TKJKWpaDygGzi/Q2fDpe/5PcsT6w==",
+      "version": "0.21.0-dev.1",
+      "resolved": "https://registry.npmjs.org/@dashevo/dapi-grpc/-/dapi-grpc-0.21.0-dev.1.tgz",
+      "integrity": "sha512-qAU+/ovCr4I85Im+QW0w4/vq8p2GN/8iFlC4Spe6NDeovoa7jtEXwFmPy8NWWaBoDEiUaXV4Debc/x/EwQPMDg==",
       "requires": {
         "@dashevo/grpc-common": "^0.3.3",
         "google-protobuf": "^3.12.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     }
   ],
   "dependencies": {
-    "@dashevo/dapi-grpc": "~0.20.0",
+    "@dashevo/dapi-grpc": "~0.21.0-dev.1",
     "@dashevo/dashcore-lib": "~0.19.25",
     "axios": "^0.21.1",
     "bs58": "^4.0.1",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Updated `dapi-grpc` dependency with fixed type for `height` in `Metadata`

## What was done?
<!--- Describe your changes in detail -->
- updated `dapi-grpc`

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
None.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
