### PR TITLE
fix: createConsensusError can be called with empty arguments

### DIFF
--- a/lib/transport/GrpcTransport/createGrpcTransportError.js
+++ b/lib/transport/GrpcTransport/createGrpcTransportError.js
@@ -110,7 +110,7 @@ function createGrpcTransportError(grpcError, dapiAddress) {
 
   // DPP consensus errors
   if (code >= 1000 && code < 5000) {
-    const consensusError = createConsensusError(code, data.arguments);
+    const consensusError = createConsensusError(code, data.arguments || []);
 
     delete data.arguments;
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
createConsensusError can be called with empty arguments if arguments field is empty

## What was done?
<!--- Describe your changes in detail -->
Fixed createConsensusError function

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
With tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
