### PR TITLE
fix: createGrpcTransportError can't get metadata in browser environment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,13 +6,14 @@
   "packages": {
     "": {
       "name": "@dashevo/dapi-client",
-      "version": "0.21.0-dev.10",
+      "version": "0.21.0-dev.11",
       "license": "MIT",
       "dependencies": {
         "@dashevo/dapi-grpc": "~0.21.0-dev.12",
         "@dashevo/dashcore-lib": "~0.19.26",
         "@dashevo/dpp": "~0.21.0-dev.5",
         "@dashevo/grpc-common": "~0.5.4",
+        "@grpc/grpc-js": "^1.3.7",
         "axios": "^0.21.1",
         "bs58": "^4.0.1",
         "cbor": "^7.0.5",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@dashevo/dashcore-lib": "~0.19.26",
     "@dashevo/dpp": "~0.21.0-dev.5",
     "@dashevo/grpc-common": "~0.5.4",
+    "@grpc/grpc-js": "^1.3.7",
     "axios": "^0.21.1",
     "bs58": "^4.0.1",
     "cbor": "^7.0.5",

--- a/test/unit/transport/GrpcTransport/createGrpcTransportError.spec.js
+++ b/test/unit/transport/GrpcTransport/createGrpcTransportError.spec.js
@@ -67,6 +67,28 @@ describe('createGrpcTransportError', () => {
     expect(error.getData()).to.deep.equal(errorData);
   });
 
+  it('should get code from metadata in browser environment', () => {
+    metadata.code = GrpcErrorCodes.INVALID_ARGUMENT;
+
+    const grpcError = new Error(
+      'Not found',
+    );
+
+    grpcError.code = GrpcErrorCodes.NOT_FOUND;
+    grpcError.metadata = metadata;
+
+    const error = createGrpcTransportError(
+      grpcError,
+      dapiAddress,
+    );
+
+    expect(error).to.be.an.instanceOf(InvalidRequestError);
+    expect(error.message).to.equal(grpcError.message);
+    expect(error.getCode()).to.equal(GrpcErrorCodes.INVALID_ARGUMENT);
+    expect(error.getDAPIAddress()).to.deep.equal(dapiAddress);
+    expect(error.getData()).to.deep.equal(errorData);
+  });
+
   it('should return InvalidRequestError', () => {
     const grpcError = new GrpcError(
       GrpcErrorCodes.INVALID_ARGUMENT,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
createGrpcTransportError can't get metadata from gRPC Error in browser environment

## What was done?
<!--- Describe your changes in detail -->
createGrpcTransportError method fixed

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
