### PR TITLE
fix: retry doesn’t work with 502 errors

### DIFF
--- a/lib/transport/JsonRpcTransport/createJsonTransportError.js
+++ b/lib/transport/JsonRpcTransport/createJsonTransportError.js
@@ -13,7 +13,7 @@ const RetriableResponseError = require('../errors/response/RetriableResponseErro
 function createJsonTransportError(error, dapiAddress) {
   if (error instanceof WrongHttpCodeError) {
     return new ServerError(
-      error.statusCode,
+      error.getCode(),
       error.message,
       {},
       dapiAddress,

--- a/lib/transport/JsonRpcTransport/errors/WrongHttpCodeError.js
+++ b/lib/transport/JsonRpcTransport/errors/WrongHttpCodeError.js
@@ -16,7 +16,7 @@ class WrongHttpCodeError extends DAPIClientError {
     super(`DAPI JSON RPC wrong http code: ${statusMessage}`);
 
     this.requestInfo = requestInfo;
-    this.statusCode = statusCode;
+    this.code = statusCode;
   }
 
   /**
@@ -30,8 +30,8 @@ class WrongHttpCodeError extends DAPIClientError {
    *
    * @returns {number}
    */
-  getStatusCode() {
-    return this.statusCode;
+  getCode() {
+    return this.code;
   }
 }
 

--- a/lib/transport/JsonRpcTransport/requestJsonRpc.js
+++ b/lib/transport/JsonRpcTransport/requestJsonRpc.js
@@ -29,12 +29,6 @@ async function requestJsonRpc(host, port, method, params, options = {}) {
     postOptions.timeout = options.timeout;
   }
 
-  const response = await axios.post(
-    url,
-    payload,
-    { timeout: options.timeout },
-  );
-
   const requestInfo = {
     host,
     port,
@@ -42,6 +36,22 @@ async function requestJsonRpc(host, port, method, params, options = {}) {
     params,
     options,
   };
+
+  let response;
+
+  try {
+    response = await axios.post(
+      url,
+      payload,
+      { timeout: options.timeout },
+    );
+  } catch (error) {
+    if (error.response && error.response.status >= 500) {
+      throw new WrongHttpCodeError(requestInfo, error.response.status, error.response.statusText);
+    }
+
+    throw error;
+  }
 
   if (response.status !== 200) {
     throw new WrongHttpCodeError(requestInfo, response.status, response.statusMessage);

--- a/test/unit/transport/JsonRpcTransport/requestJsonRpc.spec.js
+++ b/test/unit/transport/JsonRpcTransport/requestJsonRpc.spec.js
@@ -114,7 +114,7 @@ describe('requestJsonRpc', () => {
     } catch (e) {
       expect(e).to.be.an.instanceOf(WrongHttpCodeError);
       expect(e.message).to.equal('DAPI JSON RPC wrong http code: Status message');
-      expect(e.getStatusCode()).to.equal(400);
+      expect(e.getCode()).to.equal(400);
       expect(e.getRequestInfo()).to.deep.equal({
         host,
         port,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
<!--- Pull request titles must use the [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/#summary) format -->

## Issue being fixed or feature implemented
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Dapi-client doesn't retry on 502 errors

## What was done?
<!--- Describe your changes in detail -->
Fixed JsonTransport in Dapi-client

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Platform test suite

## Breaking Changes
<!--- Please describe any breaking changes your code introduces and verify that -->
<!--- the title includes "!" following the conventional commit type (e.g. "feat!: ..."-->
No

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added or updated relevant unit/integration/functional/e2e tests
- [x] I have made corresponding changes to the documentation

**For repository code-owners and collaborators only**
- [x] I have assigned this pull request to a milestone
